### PR TITLE
Ternary was returning int if true rather than post type.

### DIFF
--- a/wp-content/themes/view/classes/Compatibility/Timber/TemplateRouting.php
+++ b/wp-content/themes/view/classes/Compatibility/Timber/TemplateRouting.php
@@ -65,7 +65,7 @@ class TemplateRouting
         $context   = [];
         $type      = $this->get_view_type();
         $queried   = get_queried_object();
-        $post_type = Utils\Helpers::has_key('post_type', $queried) ?: 'post';
+	    $post_type = Utils\Helpers::has_key('post_type', $queried) ? $queried->post_type : 'post';
 
         switch ($type) {
             case 'Archives':


### PR DESCRIPTION
The has_key function returns bool, if the check returns true, the post type value is set to true. Changed it to set it to $queried->post_type.